### PR TITLE
Allow filenames longer than 32 chars for MSSQL

### DIFF
--- a/lib/commonClient.js
+++ b/lib/commonClient.js
@@ -101,7 +101,7 @@ module.exports = function(config) {
             VALUES (0);
         `)
       }
-      const textType = config.driver === 'mssql' ? 'VARCHAR(32)' : 'TEXT'
+      const textType = config.driver === 'mssql' ? 'VARCHAR(MAX)' : 'TEXT'
       const columnKeyword = config.driver === 'mssql' ? '' : 'COLUMN'
       if (!results.rows.find(row => row.column_name === 'name')) {
         sqls.push(


### PR DESCRIPTION
We have hit this limitation with our filename descriptions a couple of times.